### PR TITLE
docs: add examples for all guideline submenus

### DIFF
--- a/docs/anti-patterns.md
+++ b/docs/anti-patterns.md
@@ -3,8 +3,22 @@
 ## 8.1 Avoid `var` {#avoid-var}
 `var` has function scope and can lead to bugs. Use `let` or `const` instead.
 
+```js
+// Avoid
+var count = 0
+
+// Prefer
+let count = 0
+```
+
 ## 8.2 Avoid Deep Nesting {#avoid-deep-nesting}
 Refactor deeply nested code into smaller functions to improve readability.
+
+```js
+if (!user) return
+if (!user.isActive) return
+process(user)
+```
 
 ## 8.3 Magic Numbers & Strings {#magic-numbers}
 Replace unexplained literals with named constants.
@@ -16,5 +30,19 @@ const MAX_ITEMS = 10
 ## 8.4 Overusing Global Variables {#global-variables}
 Limit global state and prefer module exports or dependency injection.
 
+```js
+// Bad
+window.total = 0
+
+// Good
+export const total = 0
+```
+
 ## 8.5 Callback Hell {#callback-hell}
 Use promises or `async/await` to flatten complex asynchronous code.
+
+```js
+doFirst()
+  .then(doSecond)
+  .then(doThird)
+```

--- a/docs/code-formatting.md
+++ b/docs/code-formatting.md
@@ -12,11 +12,27 @@ if (ready) {
 ## 3.2 Line Length {#line-length}
 Keep lines under 100 characters. Break long statements into multiple lines for readability.
 
+```js
+const query = db
+  .select('id', 'name')
+  .from('users')
+  .where('active', true)
+```
+
 ## 3.3 Semicolons {#semicolons}
 Always include semicolons to avoid issues with automatic insertion.
 
+```js
+const total = getTotal();
+```
+
 ## 3.4 Quotation Marks {#quotation-marks}
 Use single quotes for strings and backticks for templates that need interpolation.
+
+```js
+const title = 'Guide';
+const message = `Hello, ${name}`;
+```
 
 ## 3.5 Braces & Parentheses Style {#braces-and-parentheses}
 Opening braces stay on the same line as the statement.
@@ -29,3 +45,15 @@ function hello() {
 
 ## 3.6 Trailing Commas {#trailing-commas}
 Include trailing commas in multi-line objects and arrays to minimize diff noise.
+
+```js
+const colors = [
+  'red',
+  'blue',
+];
+
+const user = {
+  id: 1,
+  name: 'Ada',
+};
+```

--- a/docs/code-structure-and-organization.md
+++ b/docs/code-structure-and-organization.md
@@ -11,11 +11,46 @@ import helpers from './helpers.js'
 ## 6.2 File Structure {#file-structure}
 Organize files by feature or domain instead of by type to keep related code together.
 
+```
+src/
+  auth/
+    login-view.vue
+    auth.service.js
+  profile/
+    profile-view.vue
+    profile.service.js
+```
+
 ## 6.3 Separation of Concerns {#separation-of-concerns}
 Each module or component should handle a single responsibility.
+
+```js
+function fetchUser(id) {
+  return api.get(`/users/${id}`)
+}
+
+function renderUser(user) {
+  userElement.textContent = user.name
+}
+```
 
 ## 6.4 Commenting & Documentation {#commenting-and-documentation}
 Explain why code exists rather than what it does. Use JSDoc for public APIs.
 
+```js
+/**
+ * Fetch a user by id.
+ * @param {number} id
+ */
+function getUser(id) {
+  // ...
+}
+```
+
 ## 6.5 TODO / FIXME Conventions {#todo-fixme}
 Use `// TODO:` for future work and `// FIXME:` for known issues. Include ticket numbers when available.
+
+```js
+// TODO: FE-123 add loading state
+// FIXME: FE-124 handle null response
+```

--- a/docs/framework-specific-guidelines.md
+++ b/docs/framework-specific-guidelines.md
@@ -3,6 +3,21 @@
 ## 9.1 Vue.js Coding Standards {#vue-coding-standards}
 Use the Composition API in new components and keep templates simple.
 
+```vue
+<script setup>
+import { ref } from 'vue'
+
+const count = ref(0)
+function increment() {
+  count.value++
+}
+</script>
+
+<template>
+  <button @click="increment">{{ count }}</button>
+</template>
+```
+
 ## 9.2 Component Naming {#component-naming}
 Component file names and tags use `PascalCase`.
 
@@ -13,11 +28,36 @@ Component file names and tags use `PascalCase`.
 ## 9.3 Props & Emits Conventions {#props-and-emits}
 Define props and emits with explicit types and avoid using `any`.
 
+```vue
+<script setup>
+const props = defineProps<{ label: string }>()
+const emit = defineEmits<{ (e: 'update'): void }>()
+</script>
+```
+
 ## 9.4 State Management Patterns (Vuex/Pinia) {#state-management}
 Centralize shared state in Vuex or Pinia and keep modules small.
+
+```js
+// stores/user.js
+export const useUserStore = defineStore('user', {
+  state: () => ({ name: '' }),
+})
+```
 
 ## 9.5 File Naming in Components {#file-naming-components}
 Store single-file components as `MyComponent.vue` and co-locate related tests or styles.
 
 ## 9.6 Testing Components {#testing-components}
 Use `@vue/test-utils` and write tests for critical interactions and edge cases.
+
+```js
+import { mount } from '@vue/test-utils'
+import MyButton from './MyButton.vue'
+
+it('emits click', () => {
+  const wrapper = mount(MyButton)
+  wrapper.trigger('click')
+  expect(wrapper.emitted()).toHaveProperty('click')
+})
+```

--- a/docs/general-principles.md
+++ b/docs/general-principles.md
@@ -3,11 +3,46 @@
 ## 2.1 Readability First {#readability-first}
 Code is read more often than it is written. Prefer clear names and straightforward logic over clever tricks.
 
+```js
+// Hard to follow
+const r = n > 10 ? x : y
+
+// Clear intent
+const isEligible = age > 10 ? childRate : adultRate
+```
+
 ## 2.2 Maintainability {#maintainability}
 Organize code so future changes are easy. Break large functions into smaller parts and avoid duplication.
+
+```js
+function saveUser(user) {
+  validate(user)
+  persist(user)
+}
+
+function validate(user) {
+  // ...
+}
+
+function persist(user) {
+  // ...
+}
+```
 
 ## 2.3 Performance Considerations {#performance}
 Optimize only when necessary. Measure bottlenecks before making changes and keep algorithms as simple as possible.
 
+```js
+console.time('render')
+renderPage()
+console.timeEnd('render')
+```
+
 ## 2.4 Security Practices {#security}
 Validate user input, escape dynamic content, and keep dependencies updated to minimize vulnerabilities.
+
+```js
+import DOMPurify from 'dompurify'
+
+const safeHtml = DOMPurify.sanitize(userInput)
+```

--- a/docs/naming-conventions.md
+++ b/docs/naming-conventions.md
@@ -25,6 +25,13 @@ class UserProfile {}
 ## 4.4 Files & Folders {#files-and-folders}
 Use `kebab-case` for file and folder names.
 
+```
+src/
+  user-profile/
+    index.js
+    user-service.js
+```
+
 ## 4.5 Boolean Naming {#boolean-naming}
 Prefix booleans with `is`, `has`, or `should` to indicate their nature.
 

--- a/docs/patterns-and-best-practices.md
+++ b/docs/patterns-and-best-practices.md
@@ -3,8 +3,23 @@
 ## 7.1 DRY & Avoiding Repetition {#dry}
 Extract common code into reusable functions to keep logic in one place.
 
+```js
+function formatName(user) {
+  return `${user.first} ${user.last}`
+}
+
+console.log(formatName(userA))
+console.log(formatName(userB))
+```
+
 ## 7.2 Pure Functions {#pure-functions}
 Functions should avoid side effects and return the same output for the same input.
+
+```js
+function add(a, b) {
+  return a + b
+}
+```
 
 ## 7.3 Immutability {#immutability}
 Prefer immutable data structures. Instead of mutating arrays, return new ones.
@@ -16,11 +31,40 @@ const updated = [...items, newItem]
 ## 7.4 Error Handling {#error-handling}
 Handle errors with `try/catch` or promise rejections and provide helpful messages.
 
+```js
+try {
+  await save()
+} catch (err) {
+  console.error('Failed to save', err)
+}
+```
+
 ## 7.5 Async/Await vs Promises {#async-await-vs-promises}
 Use `async/await` for readability while still understanding underlying promises.
+
+```js
+async function load() {
+  const data = await fetchData()
+  return data
+}
+```
 
 ## 7.6 Event Handling {#event-handling}
 Detach listeners when components unmount and keep handler names descriptive.
 
+```js
+function handleClick() {}
+button.addEventListener('click', handleClick)
+// later
+button.removeEventListener('click', handleClick)
+```
+
 ## 7.7 Data Validation {#data-validation}
 Validate external data at boundaries to prevent unexpected behavior.
+
+```js
+function createUser(input) {
+  if (!input.name) throw new Error('name required')
+  return { ...input }
+}
+```

--- a/docs/tooling-and-automation.md
+++ b/docs/tooling-and-automation.md
@@ -3,8 +3,33 @@
 ## 10.1 ESLint Rules {#eslint-rules}
 Use a shared ESLint configuration to enforce these guidelines and catch common errors.
 
+```json
+// .eslintrc.json
+{
+  "extends": ["eslint:recommended"],
+  "env": { "browser": true }
+}
+```
+
 ## 10.2 Prettier Config {#prettier-config}
 Format code automatically with a team-approved Prettier setup.
 
+```json
+// .prettierrc
+{
+  "singleQuote": true,
+  "semi": false
+}
+```
+
 ## 10.3 Git Hooks (Husky) {#git-hooks}
 Use Husky to run linting and tests before commits and pushes.
+
+```sh
+// package.json
+"husky": {
+  "hooks": {
+    "pre-commit": "npm run lint"
+  }
+}
+```


### PR DESCRIPTION
## Summary
- expand general principles with code examples
- document formatting, naming, and organization with sample snippets
- add Vue and tooling examples for framework-specific and automation sections

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run docs:build`


------
https://chatgpt.com/codex/tasks/task_e_6895cdb554e48326b20edd4e83f01699