### PR TITLE
feat: allow wide sidebar menu items

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -3,3 +3,10 @@
   border-left: 1px solid var(--vp-c-divider);
   padding-left: 16px;
 }
+
+/* Allow long sidebar titles to occupy the space they need */
+.VPSidebarItem .text {
+  flex: 0 0 auto;
+  width: auto;
+  white-space: nowrap;
+}


### PR DESCRIPTION
## Summary
- allow sidebar menu item text to use auto width so long titles don't wrap

## Testing
- `CI=1 npm run docs:build`


------
https://chatgpt.com/codex/tasks/task_e_689622a839f08326b8df984bb17ebf7b