### PR TITLE
style: widen sidebar and move caret

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -10,3 +10,14 @@
   width: auto;
   white-space: nowrap;
 }
+
+/* Increase sidebar width to prevent arrows from being hidden */
+:root {
+  --vp-sidebar-width: 320px;
+}
+
+/* Place caret arrow at the far right with spacing from the edge */
+.VPSidebarItem .caret {
+  margin-left: auto;
+  margin-right: 8px;
+}


### PR DESCRIPTION
## Summary
- widen sidebar width to fit long menu items
- align caret arrow to the right with margin

## Testing
- `npm test` *(fails: Missing script: "test")*
- `CI=1 npm run docs:build`


------
https://chatgpt.com/codex/tasks/task_e_689627a78d1c8326baa075c90c20c040