### PR TITLE
Expand sidebar for right-aligned arrows

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -10,3 +10,14 @@
   width: auto;
   white-space: nowrap;
 }
+
+/* Increase sidebar width further to keep arrows aligned */
+:root {
+  --vp-sidebar-width: 360px;
+}
+
+/* Place caret arrow at the far right with spacing from the edge */
+.VPSidebarItem .caret {
+  margin-left: auto;
+  margin-right: 8px;
+}


### PR DESCRIPTION
## Summary
- Widen sidebar to 360px so menu carets can align flush to the right edge

## Testing
- `npm test` *(fails: Missing script: "test")*
- `CI=1 npm run docs:build`


------
https://chatgpt.com/codex/tasks/task_e_689627a78d1c8326baa075c90c20c040