### PR TITLE
feat: add header logo

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -118,6 +118,7 @@ export default defineConfig({
   title: 'Frontend Coding Guidelines',
   description: 'JavaScript and Vue coding standards',
   themeConfig: {
+    logo: '/assets/hk-logo.svg',
     sidebar
   }
 })

--- a/docs/public/assets/hk-logo.svg
+++ b/docs/public/assets/hk-logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 40" role="img" aria-label="HotelKey logo placeholder">
+  <rect width="200" height="40" fill="white" />
+  <text x="0" y="28" font-size="28" font-family="Arial, Helvetica, sans-serif" fill="black">HK</text>
+  <!-- TODO: Replace this placeholder with the official HotelKey logo from https://www.hotelkeyapp.com/img/hk-logo-black.7aa504e0.svg -->
+</svg>


### PR DESCRIPTION
## Summary
- add placeholder HotelKey logo asset
- include logo in VitePress config for header

## Testing
- `npm test` (fails: Missing script "test")
- `CI=1 npm run docs:build`


------
https://chatgpt.com/codex/tasks/task_e_68970f5baa2c8326a7942459f2474fd7