### PR TITLE
feat: display site title beneath sidebar logo

### DIFF
--- a/docs/.vitepress/theme/SidebarTitle.vue
+++ b/docs/.vitepress/theme/SidebarTitle.vue
@@ -1,0 +1,31 @@
+<template>
+  <div class="sidebar-logo-title">
+    <img v-if="logo" :src="logo" alt="logo" class="logo" />
+    <div class="title">{{ title }}</div>
+  </div>
+</template>
+
+<script setup>
+import { useData } from 'vitepress'
+const { site, theme } = useData()
+const title = site.value.title
+const logo = theme.value.logo
+</script>
+
+<style scoped>
+.sidebar-logo-title {
+  text-align: center;
+  padding: 1rem 0;
+}
+.sidebar-logo-title .logo {
+  display: block;
+  margin: 0 auto;
+  height: 40px;
+}
+.sidebar-logo-title .title {
+  margin-top: 0.5rem;
+  font-weight: 600;
+  font-size: 1.2rem;
+}
+</style>
+

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -21,3 +21,8 @@
   margin-left: auto;
   margin-right: 8px;
 }
+
+/* Hide default navbar title to display it in the sidebar instead */
+.VPNavBarTitle .title {
+  display: none;
+}

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -1,6 +1,13 @@
 import DefaultTheme from 'vitepress/theme'
+import { h } from 'vue'
+import SidebarTitle from './SidebarTitle.vue'
 import './custom.css'
 
 export default {
-  ...DefaultTheme
+  ...DefaultTheme,
+  Layout() {
+    return h(DefaultTheme.Layout, null, {
+      'sidebar-top': () => h(SidebarTitle)
+    })
+  }
 }


### PR DESCRIPTION
## Summary
- show site name in the sidebar via new SidebarTitle component
- customize theme layout to render the component and hide default navbar title

## Testing
- `npm run docs:build`

------
https://chatgpt.com/codex/tasks/task_e_689715d566e083269619ab5c3264adc8