### PR TITLE
Enable local search in docs

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -119,6 +119,9 @@ export default defineConfig({
   description: 'JavaScript and Vue coding standards',
   themeConfig: {
     logo: '/assets/hk-logo.svg',
+    search: {
+      provider: 'local'
+    },
     sidebar
   }
 })


### PR DESCRIPTION
## Summary
- add VitePress local search to display a search bar in the header

## Testing
- `npm test` (fails: Missing script "test")
- `npm run docs:build`


------
https://chatgpt.com/codex/tasks/task_e_68973ffd74e88326815f3203dad11bdd