### PR TITLE
feat: add home hero block

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,9 @@
-# HotelKey Frontend Coding Guidelines
-
-Welcome to the coding standards for our frontend team. The guide covers everything from general principles and formatting to naming, syntax, Vue practices, and tooling.
-
-Use the sidebar to browse each topic and keep the codebase consistent and readable.
+---
+layout: home
+hero:
+  name: Frontend Coding Guidelines
+  text: Standards for consistent, quality code
+  actions:
+    - text: Get Started
+      link: /introduction
+---


### PR DESCRIPTION
## Summary
- add VitePress home layout with hero and CTA

## Testing
- `CI=1 npm run docs:build`


------
https://chatgpt.com/codex/tasks/task_e_689744db5ed083268757b208194a05f8