### PR TITLE
feat: add custom 404 page

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -122,7 +122,13 @@ export default defineConfig({
     search: {
       provider: 'local'
     },
-    sidebar
+    sidebar,
+    notFound: {
+      title: 'Page not found',
+      quote: 'But don\'t worry, you can go back to the homepage.',
+      linkText: 'Go back home',
+      linkHref: '/'
+    }
   }
 })
 

--- a/docs/404.md
+++ b/docs/404.md
@@ -1,0 +1,5 @@
+---
+layout: 404
+---
+# Page not found
+[Go back home](/)


### PR DESCRIPTION
## Summary
- add custom 404 page with friendly messaging
- tweak notFound config to offer a home link

## Testing
- `CI=1 npm run docs:build`
- `curl -s http://localhost:4173/nonexistent | grep -o 'Page not found' | head -n 5`
- `curl -s http://localhost:4173/nonexistent | grep -o 'Go back home' | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_689747cdecb08326a99774db17de96d1