### PR TITLE
feat: add introduction links to sidebar

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitepress'
 const sidebar = [
   {
     text: '1. Introduction',
+    base: '/introduction/',
     items: [
       { text: '1.1 Purpose of the Guidelines', link: '/introduction/purpose' },
       { text: '1.2 How to Use This Guide', link: '/introduction/how-to-use' },
@@ -12,6 +13,7 @@ const sidebar = [
   },
   {
     text: '2. General Principles',
+    base: '/general-principles/',
     items: [
       { text: '2.1 Readability First', link: '/general-principles/readability-first' },
       { text: '2.2 Maintainability', link: '/general-principles/maintainability' },
@@ -21,6 +23,7 @@ const sidebar = [
   },
   {
     text: '3. Code Formatting',
+    base: '/code-formatting/',
     items: [
       { text: '3.1 Indentation & Spacing', link: '/code-formatting/indentation-and-spacing' },
       { text: '3.2 Line Length', link: '/code-formatting/line-length' },
@@ -32,6 +35,7 @@ const sidebar = [
   },
   {
     text: '4. Naming Conventions',
+    base: '/naming-conventions/',
     items: [
       { text: '4.1 Variables & Constants', link: '/naming-conventions/variables-and-constants' },
       { text: '4.2 Functions & Methods', link: '/naming-conventions/functions-and-methods' },
@@ -45,6 +49,7 @@ const sidebar = [
   },
   {
     text: '5. Syntax & Language Features',
+    base: '/syntax-and-language-features/',
     items: [
       { text: '5.1 `let`, `const`, and `var`', link: '/syntax-and-language-features/let-const-var' },
       { text: '5.2 Arrow Functions', link: '/syntax-and-language-features/arrow-functions' },
@@ -57,6 +62,7 @@ const sidebar = [
   },
   {
     text: '6. Code Structure & Organization',
+    base: '/code-structure-and-organization/',
     items: [
       { text: '6.1 Module Imports/Exports', link: '/code-structure-and-organization/module-imports-exports' },
       { text: '6.2 File Structure', link: '/code-structure-and-organization/file-structure' },
@@ -67,6 +73,7 @@ const sidebar = [
   },
   {
     text: '7. Patterns & Best Practices',
+    base: '/patterns-and-best-practices/',
     items: [
       { text: '7.1 DRY & Avoiding Repetition', link: '/patterns-and-best-practices/dry' },
       { text: '7.2 Pure Functions', link: '/patterns-and-best-practices/pure-functions' },
@@ -79,6 +86,7 @@ const sidebar = [
   },
   {
     text: '8. Anti-Patterns',
+    base: '/anti-patterns/',
     items: [
       { text: '8.1 Avoid `var`', link: '/anti-patterns/avoid-var' },
       { text: '8.2 Avoid Deep Nesting', link: '/anti-patterns/avoid-deep-nesting' },
@@ -89,6 +97,7 @@ const sidebar = [
   },
   {
     text: '9. Framework-Specific Guidelines',
+    base: '/framework-specific-guidelines/',
     items: [
       { text: '9.1 Vue.js Coding Standards', link: '/framework-specific-guidelines/vue-coding-standards' },
       { text: '9.2 Component Naming', link: '/framework-specific-guidelines/component-naming' },
@@ -100,6 +109,7 @@ const sidebar = [
   },
   {
     text: '10. Tooling & Automation',
+    base: '/tooling-and-automation/',
     items: [
       { text: '10.1 ESLint Rules', link: '/tooling-and-automation/eslint-rules' },
       { text: '10.2 Prettier Config', link: '/tooling-and-automation/prettier-config' },
@@ -108,13 +118,25 @@ const sidebar = [
   },
   {
     text: '11. Resources',
+    base: '/resources/',
     items: [
       { text: '11.1 External Style Guides', link: '/resources/external-style-guides' },
       { text: '11.2 Useful Tools', link: '/resources/useful-tools' },
       { text: '11.3 Further Reading', link: '/resources/further-reading' }
     ]
   }
-].map((group) => ({ ...group, collapsed: true, collapsible: true }))
+].map((group, index) => {
+  const { base, items, ...rest } = group
+  return {
+    ...rest,
+    items: [
+      { text: `${index + 1}.0 Introduction`, link: base },
+      ...items
+    ],
+    collapsed: true,
+    collapsible: true
+  }
+})
 
 export default defineConfig({
   title: 'Frontend Coding Guidelines',


### PR DESCRIPTION
## Summary
- inject an Introduction entry for each sidebar group
- link each section's introduction to its index page

## Testing
- `CI=1 npm run docs:build`

------
https://chatgpt.com/codex/tasks/task_e_689a160f1640832693a4f4baddb98db5