### PR TITLE
feat: add section outline

### DIFF
--- a/docs/.vitepress/theme/SectionOutline.vue
+++ b/docs/.vitepress/theme/SectionOutline.vue
@@ -1,0 +1,59 @@
+<template>
+  <nav
+    v-if="items.length"
+    class="section-outline VPDocAsideOutline"
+    aria-labelledby="section-outline-aria-label"
+  >
+    <div class="content">
+      <div
+        class="outline-title"
+        id="section-outline-aria-label"
+        role="heading"
+        aria-level="2"
+      >
+        {{ currentGroup.text }}
+      </div>
+      <ul>
+        <li v-for="item in items" :key="item.link">
+          <a
+            class="outline-link"
+            :href="withBase(item.link)"
+            :class="{ active: isActive(item.link) }"
+            :aria-current="isActive(item.link) ? 'page' : undefined"
+          >
+            {{ item.text }}
+          </a>
+        </li>
+      </ul>
+    </div>
+  </nav>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { useData, useRoute, withBase } from 'vitepress'
+
+const { theme } = useData()
+const route = useRoute()
+
+const normalize = (path) => path.replace(/\.html$/, '').replace(/\/$/, '')
+const currentPath = computed(() => normalize(route.path))
+
+const currentGroup = computed(() => {
+  const sidebar = theme.value.sidebar || []
+  const path = currentPath.value
+  return (
+    sidebar.find((group) =>
+      group.items && group.items.some((item) => path.startsWith(normalize(item.link)))
+    ) || { items: [], text: '' }
+  )
+})
+
+const items = computed(() => currentGroup.value.items)
+
+const isActive = (link) => normalize(withBase(link)) === currentPath.value
+</script>
+
+<style scoped>
+/* No scoped styles; presentation handled in custom.css */
+</style>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -43,3 +43,45 @@
 .VPNavBarTitle .title {
   display: none;
 }
+
+/* Section outline styling to match VitePress default */
+.section-outline .content {
+  position: relative;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.section-outline ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.section-outline .outline-title {
+  line-height: 32px;
+  font-size: 14px;
+  font-weight: 600;
+  border-left: 1px solid var(--vp-c-divider);
+  padding-left: 16px;
+}
+
+.section-outline .outline-link {
+  display: block;
+  line-height: 32px;
+  font-size: 14px;
+  font-weight: 400;
+  color: var(--vp-c-text-2);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  border-left: 1px solid var(--vp-c-divider);
+  padding-left: 16px;
+  transition: color 0.5s, border-color 0.5s;
+}
+
+.section-outline .outline-link:hover,
+.section-outline .outline-link.active {
+  color: var(--vp-c-text-1);
+  border-left-color: var(--vp-c-brand-1);
+  transition: color 0.25s, border-color 0.25s;
+}

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -1,13 +1,15 @@
 import DefaultTheme from 'vitepress/theme'
 import { h } from 'vue'
 import SidebarTitle from './SidebarTitle.vue'
+import SectionOutline from './SectionOutline.vue'
 import './custom.css'
 
 export default {
   ...DefaultTheme,
   Layout() {
     return h(DefaultTheme.Layout, null, {
-      'sidebar-nav-before': () => h(SidebarTitle)
+      'sidebar-nav-before': () => h(SidebarTitle),
+      'aside-outline-after': () => h(SectionOutline)
     })
   }
 }


### PR DESCRIPTION
## Summary
- add SectionOutline component to surface sidebar group links
- mount SectionOutline using `aside-outline-after` slot and style to match default outline
- normalize routes and link styling so active section is highlighted with a colored left border

## Testing
- `npm run docs:dev`
- `CI=1 npm run docs:build`


------
https://chatgpt.com/codex/tasks/task_e_6898d99461548326858e2170ca92c0fa