### PR TITLE
docs: illustrate var hoisting pitfalls

### DIFF
--- a/docs/anti-patterns/avoid-var.md
+++ b/docs/anti-patterns/avoid-var.md
@@ -1,11 +1,40 @@
 # 8.1 Avoid `var`
 `var` has function scope and can lead to bugs. Use `let` or `const` instead.
 
+## Hoisting pitfalls
 ```js
-// Avoid
-var count = 0
+console.log(total); // undefined due to hoisting
+var total = 3;
 
-// Prefer
-let count = 0
+// console.log(totalLet); // ReferenceError: cannot access before initialization
+let totalLet = 3;
 ```
+`var` declarations are hoisted and initialized with `undefined`, making it easy to accidentally use a variable before it's assigned. `let` and `const` are also hoisted but remain in the temporal dead zone until declared, preventing unintended reads.
 
+## Scope leakage
+```js
+if (true) {
+  var leaked = 'visible outside';
+}
+console.log(leaked); // 'visible outside'
+
+if (true) {
+  let safe = 'block scoped';
+}
+console.log(safe); // ReferenceError: safe is not defined
+```
+Because `var` is function scoped, declarations inside blocks leak to the outer scope. `let` and `const` respect block scope, keeping temporary values contained.
+
+## Loop example
+```js
+for (var i = 0; i < 3; i++) {
+  setTimeout(() => console.log(i), 0);
+}
+// Outputs: 3, 3, 3
+
+for (let i = 0; i < 3; i++) {
+  setTimeout(() => console.log(i), 0);
+}
+// Outputs: 0, 1, 2
+```
+Using `let` or `const` keeps variables predictable and prevents bugs.


### PR DESCRIPTION
## Summary
- expand avoid-var guidelines with examples of hoisting and scope leakage
- show equivalent `let`/`const` patterns with explanations

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run docs:build`


------
https://chatgpt.com/codex/tasks/task_e_689c83e127f083269f5aae5c2d3949aa