### PR TITLE
docs: illustrate callback hell and async/await

### DIFF
--- a/docs/anti-patterns/callback-hell.md
+++ b/docs/anti-patterns/callback-hell.md
@@ -6,3 +6,33 @@ doFirst()
   .then(doSecond)
   .then(doThird)
 ```
+
+Nested callbacks can quickly become unreadable:
+
+```js
+getUser(id, function (err, user) {
+  if (err) return handleError(err)
+  getPosts(user, function (err, posts) {
+    if (err) return handleError(err)
+    sendEmail(user, posts, function (err) {
+      if (err) handleError(err)
+    })
+  })
+})
+```
+
+Refactor using `async/await` for a clearer flow:
+
+```js
+async function main() {
+  try {
+    const user = await getUser(id)
+    const posts = await getPosts(user)
+    await sendEmail(user, posts)
+  } catch (err) {
+    handleError(err)
+  }
+}
+```
+
+Promises also enable centralized error handling through `catch` or `try/catch` blocks instead of repeated `if (err)` checks.


### PR DESCRIPTION
## Summary
- add nested callback example and async/await refactor
- note centralized error handling with promises

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run docs:build`


------
https://chatgpt.com/codex/tasks/task_e_689c83eb65008326aa3915e965b500c3