### PR TITLE
docs: warn against global mutations

### DIFF
--- a/docs/anti-patterns/global-variables.md
+++ b/docs/anti-patterns/global-variables.md
@@ -9,3 +9,58 @@ window.total = 0
 export const total = 0
 ```
 
+Globals are shared across the entire application, so a single mutation can
+produce bugs far from its source. Forgetting a declaration is a common cause of
+accidental global state:
+
+```js
+// cart.js
+function addItem(price) {
+  total += price // `total` becomes a global
+}
+
+// discount.js
+function applyDiscount(percent) {
+  total -= total * percent // mutates the same global
+}
+```
+
+`applyDiscount` assumes it owns `total`, unexpectedly altering the value used by
+`addItem`.
+
+Mitigate this by keeping state inside a module or injecting it where needed:
+
+```js
+// cart.js - module scoped state
+let total = 0
+export function addItem(price) {
+  total += price
+}
+export function applyDiscount(percent) {
+  total -= total * percent
+}
+export function getTotal() {
+  return total
+}
+```
+
+```js
+// cart.js - dependency injection
+export function createCart(total = 0) {
+  return {
+    addItem(price) {
+      total += price
+    },
+    applyDiscount(percent) {
+      total -= total * percent
+    },
+    getTotal() {
+      return total
+    }
+  }
+}
+const cart = createCart()
+```
+
+Using modules or dependency injection makes mutations explicit and localized.
+


### PR DESCRIPTION
## Summary
- expand global variable anti-pattern with example of accidental global mutation
- show module scoping and dependency injection strategies for safer state handling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run docs:build`

------
https://chatgpt.com/codex/tasks/task_e_689c83fe52548326a60a49be68962a9f