### PR TITLE
docs: expand anti-pattern index

### DIFF
--- a/docs/anti-patterns/index.md
+++ b/docs/anti-patterns/index.md
@@ -1,2 +1,18 @@
 # 8. Anti-Patterns
 
+Avoid these common pitfalls:
+
+- [Avoid `var`](avoid-var.md): `var` has function scope and can lead to bugs. Use `let` or `const` instead.
+- [Avoid Deep Nesting](avoid-deep-nesting.md): Refactor deeply nested code into smaller functions to improve readability.
+- [Magic Numbers & Strings](magic-numbers.md): Replace unexplained literals with named constants.
+- [Overusing Global Variables](global-variables.md): Limit global state and prefer module exports or dependency injection.
+- [Callback Hell](callback-hell.md): Use promises or `async/await` to flatten complex asynchronous code.
+
+## Risk Groups
+
+| Risk | Anti-Patterns |
+| ---- | ------------- |
+| Readability | [Avoid Deep Nesting](avoid-deep-nesting.md), [Magic Numbers & Strings](magic-numbers.md) |
+| Maintenance | [Avoid `var`](avoid-var.md), [Overusing Global Variables](global-variables.md), [Callback Hell](callback-hell.md) |
+| Performance | — |
+


### PR DESCRIPTION
## Summary
- add cross-linked summaries for each anti-pattern
- group anti-patterns by readability, maintenance, and performance risk

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run docs:build`

------
https://chatgpt.com/codex/tasks/task_e_689c841061408326ad03a169a41f7ae6