### PR TITLE
docs: clarify brace style preferences

### DIFF
--- a/docs/code-formatting/braces-and-parentheses.md
+++ b/docs/code-formatting/braces-and-parentheses.md
@@ -1,9 +1,35 @@
 # 3.5 Braces & Parentheses Style
-Opening braces stay on the same line as the statement.
+
+Opening braces stay on the same line as the statement. This is known as the Kernighan and Ritchie (K&R) style and is the preferred convention in this project.
+
+## K&R (preferred)
 
 ```js
 function hello() {
+  return "hi";
+}
+```
+
+## Allman (not preferred)
+
+<!-- prettier-ignore -->
+```js
+function hello()
+{
   return 'hi'
 }
 ```
 
+Prettier automatically enforces the K&R style. When run on an Allman-style snippet, Prettier rewrites it to K&R formatting:
+
+```bash
+npx prettier allman.js
+```
+
+Output:
+
+```js
+function hello() {
+  return "hi";
+}
+```


### PR DESCRIPTION
## Summary
- document K&R as the preferred brace style with Allman comparison
- show Prettier reformatting Allman style to K&R

## Testing
- `npx prettier docs/code-formatting/braces-and-parentheses.md --check`
- `CI=1 npm run docs:build`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689c84461cec8326aa69728df976b862