### PR TITLE
docs: expand quotation marks guidelines

### DIFF
--- a/docs/code-formatting/quotation-marks.md
+++ b/docs/code-formatting/quotation-marks.md
@@ -1,8 +1,23 @@
 # 3.4 Quotation Marks
 Use single quotes for strings and backticks for templates that need interpolation.
+JSX attributes should use double quotes.
 
 ```js
+// Single vs. double quotes
 const title = 'Guide';
-const message = `Hello, ${name}`;
+const quote = "He said 'hello'";
+
+// Template literal
+const message = `Hello, ${name}!`;
 ```
+
+```jsx
+// JSX attributes use double quotes
+const label = 'Save';
+return <button title="Save" className="primary">{label}</button>;
+```
+
+Linters such as ESLint and Prettier detect mixed quotation styles.
+Rules like `quotes` and `jsx-quotes` warn when strings or JSX attributes
+don't follow the project's chosen convention.
 


### PR DESCRIPTION
## Summary
- add examples comparing single vs. double quotes, JSX attributes, and template literals
- explain how linters like ESLint and Prettier enforce consistent quotation mark usage

## Testing
- `npm test` *(fails: Missing script "test")*
- `CI=1 npm run docs:build`


------
https://chatgpt.com/codex/tasks/task_e_689c85294aa4832699b580c8be6acf99