### PR TITLE
docs: illustrate semicolon pitfalls

### DIFF
--- a/docs/code-formatting/semicolons.md
+++ b/docs/code-formatting/semicolons.md
@@ -5,3 +5,28 @@ Always include semicolons to avoid issues with automatic insertion.
 const total = getTotal();
 ```
 
+Automatic semicolon insertion can cause bugs. For example, returning an object
+literal without a semicolon on the previous line results in `undefined`:
+
+```js
+function getObject() {
+  return
+  {
+    value: 42
+  };
+}
+
+getObject(); // returns undefined
+```
+
+Enforce semicolon usage with ESLint:
+
+```json
+// .eslintrc.json
+{
+  "rules": {
+    "semi": ["error", "always"]
+  }
+}
+```
+


### PR DESCRIPTION
## Summary
- document an example where automatic semicolon insertion returns `undefined`
- show ESLint config enforcing semicolon usage

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_689c84ae4aa48326a268f0af54dd9ca7