### PR TITLE
docs: explain trailing comma diffs

### DIFF
--- a/docs/code-formatting/trailing-commas.md
+++ b/docs/code-formatting/trailing-commas.md
@@ -12,3 +12,28 @@ const user = {
   name: 'Ada',
 };
 ```
+
+When you add new items, trailing commas keep diffs focused on the lines you actually change.
+
+**Without trailing commas**
+
+```diff
+ const colors = [
+   'red',
+-  'blue'
++  'blue',
++  'green',
+ ]
+```
+
+**With trailing commas**
+
+```diff
+ const colors = [
+   'red',
+   'blue',
++  'green',
+ ]
+```
+
+This style is compatible with Prettier's `trailingComma` option when set to `"es5"` or `"all"`.


### PR DESCRIPTION
## Summary
- document cleaner git diffs when arrays include trailing commas
- note compatibility with Prettier's `trailingComma` option

## Testing
- `npm run docs:build`


------
https://chatgpt.com/codex/tasks/task_e_689c853e47688326ba8cd3de1946ee45