### PR TITLE
docs: expand commenting guidelines

### DIFF
--- a/docs/code-structure-and-organization/commenting-and-documentation.md
+++ b/docs/code-structure-and-organization/commenting-and-documentation.md
@@ -1,13 +1,44 @@
 # 6.4 Commenting & Documentation
-Explain why code exists rather than what it does. Use JSDoc for public APIs.
+
+Explain why code exists rather than what it does. Strive for code that is
+self-documenting through clear naming and structure, and use comments to capture
+intent or context that the code cannot express. Public APIs should include
+JSDoc or TypeScript doc comments.
+
+## Meaningful comments vs. self-documenting code
+
+- **Let code speak for itself.** Prefer descriptive function and variable names
+  over explanatory inline comments.
+- **Comment the "why" not the "what".** Explain business rules, trade-offs, or
+  other reasoning that led to the implementation.
+- **Avoid noise.** Remove comments that merely restate obvious code and keep
+  documentation up to date.
+
+## Examples
+
+### JSDoc
 
 ```js
 /**
  * Fetch a user by id.
- * @param {number} id
+ * @param {number} id - Unique user identifier.
+ * @returns {Promise<User>} Resolves with the requested user.
  */
-function getUser(id) {
-  // ...
+async function getUser(id) {
+  // implementation
+}
+```
+
+### TypeScript
+
+```ts
+/**
+ * Compute the distance between two points in 2D space.
+ */
+export function distance(a: Point, b: Point): number {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  return Math.hypot(dx, dy);
 }
 ```
 


### PR DESCRIPTION
## Summary
- advise on using comments sparingly and focusing on intent
- add JSDoc and TypeScript doc comment examples

## Testing
- `npm test` *(fails: Missing script: "test")*
- `CI=1 npm run docs:build`

------
https://chatgpt.com/codex/tasks/task_e_689c857483f48326906193c24ad57364