### PR TITLE
docs: clarify React and Vue component naming conventions

### DIFF
--- a/docs/framework-specific-guidelines/component-naming.md
+++ b/docs/framework-specific-guidelines/component-naming.md
@@ -1,7 +1,39 @@
 # 9.2 Component Naming
 Component file names and tags use `PascalCase`.
 
+## React Components
+
+- Name components and their containing folders using `PascalCase`.
+- Use `.jsx` or `.tsx` extensions for component files.
+- Keep each component in its own folder within `src/components/`.
+
+```jsx
+src/components/MyButton/MyButton.jsx
+
+function MyButton() {
+  return <button>Click me</button>;
+}
+
+export default MyButton;
+```
+
+## Vue Single-File Components
+
+- Use `PascalCase` for `.vue` filenames.
+- Store components in a `components/` directory; create subfolders as needed.
+- Declare the component's `name` option in `PascalCase`.
+
 ```vue
-<MyButton />
+src/components/MyButton.vue
+
+<template>
+  <button>Click me</button>
+</template>
+
+<script>
+export default {
+  name: 'MyButton'
+};
+</script>
 ```
 


### PR DESCRIPTION
## Summary
- document PascalCase React component files with directory and extension guidance
- outline Vue SFC naming with `.vue` extension and placement in components directories

## Testing
- `npm test` *(fails: Missing script "test")*
- `CI=1 npm run docs:build`


------
https://chatgpt.com/codex/tasks/task_e_689c85d079b88326be15c6237621b59c