### PR TITLE
docs: expand framework guidelines

### DIFF
--- a/docs/framework-specific-guidelines/index.md
+++ b/docs/framework-specific-guidelines/index.md
@@ -1,2 +1,25 @@
 # 9. Framework-Specific Guidelines
 
+This section collects guidance for popular JavaScript frameworks used by the
+team. The patterns in this repository draw on the best practices from the
+ecosystems below and can be adapted as new frameworks emerge.
+
+## Covered frameworks
+
+Our current recommendations focus on:
+
+- **React** – see the [React documentation](https://react.dev/learn) and the
+  [React community style guide](https://github.com/airbnb/javascript/tree/master/react).
+- **Angular** – refer to the official
+  [Angular style guide](https://angular.io/guide/styleguide) for detailed
+  conventions.
+- **Vue** – follow the [Vue style guide](https://vuejs.org/style-guide/) for
+  idiomatic component design.
+
+### Adapting to other frameworks
+
+While these frameworks are highlighted today, the underlying patterns are
+framework-agnostic. As new frameworks gain traction, these guidelines should be
+treated as adaptable templates rather than fixed rules.
+
+


### PR DESCRIPTION
## Summary
- describe frameworks covered in framework-specific guidelines
- reference official style guides for React, Angular, and Vue
- note that patterns can adapt to new frameworks

## Testing
- `npm test` *(fails: Missing script)*
- `CI=1 npm run docs:build`


------
https://chatgpt.com/codex/tasks/task_e_689c85d94ba083269ae017c880c73e99