### PR TITLE
docs: add validated props and typed emits example

### DIFF
--- a/docs/framework-specific-guidelines/props-and-emits.md
+++ b/docs/framework-specific-guidelines/props-and-emits.md
@@ -1,10 +1,38 @@
 # 9.3 Props & Emits Conventions
-Define props and emits with explicit types and avoid using `any`.
+Define props and emits with explicit types and avoid using `any`. Props should be
+validated at runtime and events must be typed.
 
 ```vue
-<script setup>
-const props = defineProps<{ label: string }>()
-const emit = defineEmits<{ (e: 'update'): void }>()
+<script setup lang="ts">
+import type { PropType } from 'vue'
+
+const props = defineProps({
+  label: {
+    type: String,
+    required: true
+  },
+  size: {
+    type: String as PropType<'sm' | 'lg'>,
+    default: 'sm'
+  }
+})
+
+const emit = defineEmits<{
+  /** Fired when the button is clicked. */
+  (e: 'click', event: MouseEvent): void
+}>()
+
+function handleClick(event: MouseEvent) {
+  emit('click', event)
+}
 </script>
+
+<template>
+  <button :class="`btn-${size}`" @click="handleClick">{{ label }}</button>
+</template>
 ```
+
+Document each event so consumers know when it fires and what payload it
+provides. Use TSDoc comments in the `defineEmits` declaration or an **Events**
+section in component documentation to describe the event name and payload type.
 


### PR DESCRIPTION
## Summary
- document Vue props & emits typing with a full component example
- note how to describe emitted events for consumers

## Testing
- `CI=1 npm run docs:build >/tmp/build.log && tail -n 20 /tmp/build.log`


------
https://chatgpt.com/codex/tasks/task_e_689c85dbd6408326b029d8dae2056a86