### PR TITLE
docs: add Testing Library example for component tests

### DIFF
--- a/docs/framework-specific-guidelines/testing-components.md
+++ b/docs/framework-specific-guidelines/testing-components.md
@@ -11,3 +11,17 @@ it('emits click', () => {
   expect(wrapper.emitted()).toHaveProperty('click')
 })
 ```
+
+For React components, Jest with Testing Library provides an ergonomic way to render components and assert on the DOM output.
+
+```js
+import { render, screen } from '@testing-library/react'
+import Greeting from './Greeting'
+
+test('renders greeting', () => {
+  render(<Greeting name="Ada" />)
+  expect(screen.getByText('Hello, Ada')).toBeInTheDocument()
+})
+```
+
+Avoid heavy reliance on snapshot testing. Snapshots can hide meaningful changes—prefer explicit assertions and limit snapshots to small, stable pieces of UI.


### PR DESCRIPTION
## Summary
- document React component test with Jest and Testing Library
- caution against overusing snapshot tests

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c85eb6ba8832682551fe79d0895dd