### PR TITLE
docs: expand Vue coding standards with style guide links

### DIFF
--- a/docs/framework-specific-guidelines/vue-coding-standards.md
+++ b/docs/framework-specific-guidelines/vue-coding-standards.md
@@ -1,5 +1,6 @@
 # 9.1 Vue.js Coding Standards
-Use the Composition API in new components and keep templates simple.
+
+Use the Composition API in new components and keep templates simple. For comprehensive guidance, consult the [official Vue Style Guide](https://vuejs.org/style-guide/).
 
 ```vue
 <script setup>
@@ -16,3 +17,29 @@ function increment() {
 </template>
 ```
 
+## Common Pitfalls
+
+### Mutating props
+
+Avoid mutating props directly as it breaks one-way data flow ([style guide rule](https://vuejs.org/style-guide/rules-essential.html#no-mutating-props)).
+
+```vue
+<script setup>
+const props = defineProps({ label: String })
+
+// ❌ Bad: mutating the prop
+props.label = 'New label'
+
+// ✅ Good: use a local ref
+const localLabel = ref(props.label)
+localLabel.value = 'New label'
+</script>
+```
+
+### Missing `key` with `v-for`
+
+Always provide a unique `key` when rendering lists ([style guide rule](https://vuejs.org/style-guide/rules-essential.html#require-key-with-v-for)).
+
+```vue
+<li v-for="item in items" :key="item.id">{{ item.name }}</li>
+```


### PR DESCRIPTION
## Summary
- reference official Vue Style Guide and show Composition API snippet
- document pitfalls like mutating props and missing `key` with `v-for`

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run docs:build`


------
https://chatgpt.com/codex/tasks/task_e_689c85eba84c832689ea70502b46c6b6