### PR TITLE
docs: improve security guidance

### DIFF
--- a/docs/general-principles/security.md
+++ b/docs/general-principles/security.md
@@ -1,8 +1,19 @@
 # 2.4 Security Practices
 Validate user input, escape dynamic content, and keep dependencies updated to minimize vulnerabilities.
 
+Unsanitized HTML can expose your application to cross-site scripting (XSS):
+
+```js
+const userInput = '<img src=x onerror="alert(1)">'
+output.innerHTML = userInput // unsafe
+```
+
+Sanitize user-generated content before inserting it:
+
 ```js
 import DOMPurify from 'dompurify'
 
-const safeHtml = DOMPurify.sanitize(userInput)
+output.innerHTML = DOMPurify.sanitize(userInput)
 ```
+
+Run dependency auditing tools such as `npm audit` or `npx snyk test` to identify vulnerable packages.


### PR DESCRIPTION
## Summary
- illustrate XSS risk from unsafe HTML injection
- show DOMPurify usage for sanitizing user content
- mention dependency auditing tools such as `npm audit`

## Testing
- `npm run docs:build`

------
https://chatgpt.com/codex/tasks/task_e_689c862fcf1c8326a4f4ac4738065bf5