### PR TITLE
docs: summarize intro sections

### DIFF
--- a/docs/introduction/index.md
+++ b/docs/introduction/index.md
@@ -1,2 +1,16 @@
 # 1. Introduction
 
+Anyone contributing to our frontend codebase should read these guidelines to keep our work consistent and maintainable.
+
+## 1.1 Purpose of the Guidelines
+These guidelines establish a shared understanding of style and quality so the codebase remains consistent across the team.
+
+## 1.2 How to Use This Guide
+Browse the sidebar to find topics. Each section includes brief explanations and small examples that you can apply directly in daily work.
+
+## 1.3 Scope (What's Covered / Not Covered)
+The guide focuses on JavaScript, Vue, and related tooling. It does not attempt to replace framework documentation or cover backend languages.
+
+## 1.4 Versioning & Change Process
+Changes are proposed through pull requests. Each update increases the minor version and includes a changelog entry so teams can track revisions.
+


### PR DESCRIPTION
## Summary
- add overview text summarizing purpose, scope, and versioning of guidelines
- note that anyone contributing to the frontend codebase should read the guide
- include brief instructions on how to use the guide

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run docs:build`
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_689c8641b7dc83268b0dfa43a945cbbd