### PR TITLE
docs: clarify scope of guidelines

### DIFF
--- a/docs/introduction/scope.md
+++ b/docs/introduction/scope.md
@@ -1,3 +1,9 @@
 # 1.3 Scope (What's Covered / Not Covered)
-The guide focuses on JavaScript, Vue, and related tooling. It does not attempt to replace framework documentation or cover backend languages.
 
+This guide covers front-end development using **JavaScript** and **TypeScript**, including patterns and best practices for frameworks such as **Vue** and **React** and the tooling that supports them (build systems, linting, formatting, etc.). It focuses on writing client-side code.
+
+It explicitly excludes topics like backend API design, database modeling, server-side frameworks, and infrastructure. Those areas are governed by separate backend or DevOps guidelines.
+
+## Example
+
+When building a new analytics dashboard, you can consult this guide for how to structure your Vue components, type data with TypeScript, and apply consistent naming conventions. Designing the REST endpoint that supplies the dashboard's data is outside this guide's scope and should follow backend API standards.


### PR DESCRIPTION
## Summary
- expand scope section to outline covered frontend areas such as JS/TS and Vue/React
- note exclusions like backend API design and infrastructure
- add a concrete example showing the limits of the guidelines

## Testing
- `npm test` *(fails: Missing script "test")*
- `CI=1 npm run docs:build`


------
https://chatgpt.com/codex/tasks/task_e_689c864af14483269ef6d0b226d3184c