### PR TITLE
docs: clarify function naming

### DIFF
--- a/docs/naming-conventions/functions-and-methods.md
+++ b/docs/naming-conventions/functions-and-methods.md
@@ -19,11 +19,26 @@ function updateProfile() {
   // Update the user's profile information
 }
 
-function calculateTotalPrice(items) {
-  // Calculate the total price of all items in the cart
+function calculateTotal(items) {
+  // Calculate the total amount for the provided items
 }
 ```
 :::
+
+
+## Asynchronous Functions
+
+Indicate when a function performs asynchronous work. Prefix names with verbs like `load` or add an `Async` suffix when appropriate.
+
+```javascript
+async function loadUserData() {
+  // Fetch user information from the API
+}
+
+async function fetchUserDataAsync() {
+  // Fetch user information from the API
+}
+```
 
 
 


### PR DESCRIPTION
## Summary
- add examples like `fetchUserData` and `calculateTotal`
- document naming conventions for async functions using `load` or `Async`

## Testing
- `npm test` *(fails: Missing script "test")*
- `CI=1 npm run docs:build`


------
https://chatgpt.com/codex/tasks/task_e_689c8670cb548326957f417dcac23b60