### PR TITLE
docs: illustrate async/await conversion

### DIFF
--- a/docs/patterns-and-best-practices/async-await-vs-promises.md
+++ b/docs/patterns-and-best-practices/async-await-vs-promises.md
@@ -2,9 +2,23 @@
 Use `async/await` for readability while still understanding underlying promises.
 
 ```js
+// Promise chaining
+fetchData()
+  .then(data => transform(data))
+  .then(result => console.log(result))
+  .catch(err => console.error('Failed to load', err))
+
+// Refactored with async/await
 async function load() {
-  const data = await fetchData()
-  return data
+  try {
+    const data = await fetchData()
+    const result = await transform(data)
+    console.log(result)
+  } catch (err) {
+    console.error('Failed to load', err)
+  }
 }
 ```
+
+**Error handling:** A `.catch()` at the end of a promise chain handles rejections from any step, while `async/await` relies on `try/catch`. Forgetting `try/catch` results in unhandled promise rejections, but it also lets you handle errors at different points in the sequence.
 


### PR DESCRIPTION
## Summary
- add promise chaining snippet and async/await refactor
- clarify how error handling differs between .catch and try/catch

## Testing
- `npm test` *(fails: Missing script: "test" )*

------
https://chatgpt.com/codex/tasks/task_e_689c86832b048326a0d14add362f46ce