### PR TITLE
docs: expand event handling section

### DIFF
--- a/docs/patterns-and-best-practices/event-handling.md
+++ b/docs/patterns-and-best-practices/event-handling.md
@@ -3,22 +3,52 @@ Detach listeners when components unmount and keep handler names descriptive. Use
 event delegation to reduce the number of listeners and always remove listeners
 to prevent memory leaks.
 
-```js
-const list = document.getElementById('todo-list')
+Vue event delegation example:
+
+```vue
+<template>
+  <ul @click="handleListClick">
+    <li v-for="todo in todos" :key="todo.id">
+      {{ todo.text }}
+      <button class="remove">Remove</button>
+    </li>
+  </ul>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+
+const todos = ref([{ id: 1, text: 'Learn' }])
 
 function handleListClick(event) {
-  if (event.target.matches('li button.remove')) {
-    event.target.closest('li').remove()
+  if (event.target.closest('button.remove')) {
+    // remove the todo
   }
 }
-
-list.addEventListener('click', handleListClick)
-// later
-list.removeEventListener('click', handleListClick)
+</script>
 ```
 
-Frameworks often wrap native events in synthetic events (e.g., React's
-`SyntheticEvent`). Use lifecycle hooks (such as React's `useEffect` cleanup) to
-detach listeners and call `event.persist()` if you need the synthetic event
-asynchronously.
+Listener cleanup with lifecycle hooks:
+
+```vue
+<script setup>
+import { onMounted, onUnmounted } from 'vue'
+
+function handleResize() {
+  // handle resize
+}
+
+onMounted(() => {
+  window.addEventListener('resize', handleResize)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('resize', handleResize)
+})
+</script>
+```
+
+Some frameworks wrap native events in synthetic objects. When working with such
+synthetic events, clean up listeners using lifecycle hooks and persist the event
+object if you need to access it asynchronously.
 

--- a/docs/patterns-and-best-practices/event-handling.md
+++ b/docs/patterns-and-best-practices/event-handling.md
@@ -1,10 +1,24 @@
 # 7.6 Event Handling
-Detach listeners when components unmount and keep handler names descriptive.
+Detach listeners when components unmount and keep handler names descriptive. Use
+event delegation to reduce the number of listeners and always remove listeners
+to prevent memory leaks.
 
 ```js
-function handleClick() {}
-button.addEventListener('click', handleClick)
+const list = document.getElementById('todo-list')
+
+function handleListClick(event) {
+  if (event.target.matches('li button.remove')) {
+    event.target.closest('li').remove()
+  }
+}
+
+list.addEventListener('click', handleListClick)
 // later
-button.removeEventListener('click', handleClick)
+list.removeEventListener('click', handleListClick)
 ```
+
+Frameworks often wrap native events in synthetic events (e.g., React's
+`SyntheticEvent`). Use lifecycle hooks (such as React's `useEffect` cleanup) to
+detach listeners and call `event.persist()` if you need the synthetic event
+asynchronously.
 

--- a/docs/patterns-and-best-practices/event-handling.md
+++ b/docs/patterns-and-best-practices/event-handling.md
@@ -1,4 +1,9 @@
 # 7.6 Event Handling
+This document outlines best practices for working with events in Vue
+applications. It covers delegation to minimize listeners, explains how
+propagation works, demonstrates how to remove listeners to avoid memory leaks,
+and touches on handling synthetic events from frameworks.
+
 Detach listeners when components unmount and keep handler names descriptive. Use
 event delegation to reduce the number of listeners and always remove listeners
 to prevent memory leaks.

--- a/docs/patterns-and-best-practices/event-handling.md
+++ b/docs/patterns-and-best-practices/event-handling.md
@@ -8,7 +8,11 @@ Vue event delegation example:
 ```vue
 <template>
   <ul @click="handleListClick">
-    <li v-for="todo in todos" :key="todo.id">
+    <li
+      v-for="todo in todos"
+      :key="todo.id"
+      :data-id="todo.id"
+    >
       {{ todo.text }}
       <button class="remove">Remove</button>
     </li>
@@ -18,15 +22,43 @@ Vue event delegation example:
 <script setup>
 import { ref } from 'vue'
 
-const todos = ref([{ id: 1, text: 'Learn' }])
+const todos = ref([
+  { id: 1, text: 'Learn' },
+  { id: 2, text: 'Build' }
+])
 
 function handleListClick(event) {
-  if (event.target.closest('button.remove')) {
-    // remove the todo
+  const button = event.target.closest('button.remove')
+  if (button) {
+    const id = Number(button.closest('li').dataset.id)
+    todos.value = todos.value.filter((t) => t.id !== id)
   }
 }
 </script>
 ```
+
+Event propagation allows the single `<ul>` listener to catch clicks that
+originate from its descendant buttons because events bubble from the target up
+through ancestor elements. You can also intercept events during the capturing
+phase or stop them from bubbling:
+
+```vue
+<template>
+  <div @click.capture="log('capture')" @click="log('bubble')">
+    <button @click.stop="log('button')">Click</button>
+  </div>
+</template>
+
+<script setup>
+function log(phase) {
+  console.log(phase)
+}
+</script>
+```
+
+Clicking the button logs `capture` and then `button`; the bubbling handler on
+the `<div>` is skipped because the `.stop` modifier prevents further
+propagation.
 
 Listener cleanup with lifecycle hooks:
 


### PR DESCRIPTION
## Summary
- expand event handling guidelines with delegated listener example
- note cleanup to avoid leaks and mention synthetic events in frameworks

## Testing
- `npm test` *(fails: Missing script "test")*
- `CI=1 npm run docs:build`


------
https://chatgpt.com/codex/tasks/task_e_689c86ad01388326a5a7f1b4d431d167