### PR TITLE
docs: summarize patterns with external links

### DIFF
--- a/docs/patterns-and-best-practices/index.md
+++ b/docs/patterns-and-best-practices/index.md
@@ -1,2 +1,10 @@
 # 7. Patterns & Best Practices
 
+- [DRY & Avoiding Repetition](./dry.md): Extract shared logic into reusable functions to minimize duplication. [Wikipedia](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself).
+- [Pure Functions](./pure-functions.md): Write deterministic functions without side effects. [Wikipedia](https://en.wikipedia.org/wiki/Pure_function).
+- [Immutability](./immutability.md): Prefer immutable data structures to avoid unintended mutations. [MDN](https://developer.mozilla.org/en-US/docs/Glossary/Immutability).
+- [Error Handling](./error-handling.md): Handle and report errors gracefully to maintain stability. [MDN](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Error_handling).
+- [Async/Await vs Promises](./async-await-vs-promises.md): Use async/await for clarity while understanding the underlying Promises. [MDN](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Async_await).
+- [Event Handling](./event-handling.md): Manage event listeners cleanly and remove them when no longer needed. [MDN](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events).
+- [Data Validation](./data-validation.md): Validate inputs at boundaries to protect against malformed data. [OWASP](https://owasp.org/www-community/controls/Input_Validation).
+


### PR DESCRIPTION
## Summary
- add one-line summaries for patterns and best practices
- cross-link each pattern to an external reference

## Testing
- `npm run docs:build`

------
https://chatgpt.com/codex/tasks/task_e_689c86c7b0bc8326a882db226b494d82