### PR TITLE
docs: add impure vs pure function example

### DIFF
--- a/docs/patterns-and-best-practices/pure-functions.md
+++ b/docs/patterns-and-best-practices/pure-functions.md
@@ -7,3 +7,21 @@ function add(a, b) {
 }
 ```
 
+An impure function relies on external state like the current time:
+
+```js
+function stamp(message) {
+  return `${Date.now()}: ${message}`
+}
+```
+
+To make it pure, inject the changing value so the same input produces the same output:
+
+```js
+function stamp(message, timestamp) {
+  return `${timestamp}: ${message}`
+}
+```
+
+Pure functions are deterministic, so tests can call them with fixed inputs and assert on exact outputs without mocking global state.
+


### PR DESCRIPTION
## Summary
- illustrate an impure function using `Date.now`
- show pure alternative that accepts a timestamp
- note how determinism simplifies testing

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c86cd5784832693e0ea39193ecf48