### PR TITLE
docs: expand external style guide references

### DIFF
--- a/docs/resources/external-style-guides.md
+++ b/docs/resources/external-style-guides.md
@@ -1,4 +1,7 @@
 # 11.1 External Style Guides
-- [Airbnb JavaScript Style Guide](https://github.com/airbnb/javascript)
-- [Vue Style Guide](https://vuejs.org/style-guide/)
+
+- [Airbnb JavaScript Style Guide](https://github.com/airbnb/javascript) – comprehensive and widely adopted conventions for writing JavaScript and React.
+- [Google JavaScript Style Guide](https://google.github.io/styleguide/jsguide.html) – Google's official standards for readable, maintainable JavaScript code.
+- [Vue Style Guide](https://vuejs.org/style-guide/) – official best practices and conventions for Vue.js applications.
+- [React Official Guide](https://react.dev/learn) – official documentation outlining recommended patterns for building React components and apps.
 


### PR DESCRIPTION
## Summary
- add descriptions and links for Airbnb, Google, Vue, and React style guides

## Testing
- `npm run docs:build`

------
https://chatgpt.com/codex/tasks/task_e_689c86d602108326887a2cec1c842a0f