### PR TITLE
docs: expand further reading resources

### DIFF
--- a/docs/resources/further-reading.md
+++ b/docs/resources/further-reading.md
@@ -1,3 +1,8 @@
 # 11.3 Further Reading
-- [MDN Web Docs](https://developer.mozilla.org/)
-- [JavaScript Info](https://javascript.info/)
+
+- [MDN Web Docs](https://developer.mozilla.org/) - Comprehensive, up-to-date reference for web standards and APIs.
+- [JavaScript Info](https://javascript.info/) - In-depth tutorials covering JavaScript from basics to advanced topics.
+- [Clean Code](https://www.oreilly.com/library/view/clean-code/9780136083238/) - Classic book on writing readable, maintainable code; its principles apply to frontend development.
+- [You Don't Know JS](https://github.com/getify/You-Dont-Know-JS) - Book series exploring the nuances of JavaScript to deepen your understanding.
+- [CSS-Tricks](https://css-tricks.com/) - Blog featuring practical tips and patterns for modern CSS and frontend work.
+- [Smashing Magazine](https://www.smashingmagazine.com/) - Articles from industry experts on frontend design, performance, and best practices.


### PR DESCRIPTION
## Summary
- add book and blog recommendations to further reading
- include short descriptions for each resource

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run docs:build`


------
https://chatgpt.com/codex/tasks/task_e_689c86dc0fb4832682b17368b535b4c2