### PR TITLE
docs: add navigation overview

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,3 +7,21 @@ hero:
     - text: Get Started
       link: /introduction
 ---
+
+Welcome! Use the sidebar navigation or search box to explore topics. Each section below links to a dedicated area with detailed guidance.
+
+## Table of Contents
+
+- [Introduction](./introduction/) - Overview, scope, and how to use this guide.
+- [General Principles](./general-principles/) - Core philosophies for readable, maintainable, and secure code.
+- [Code Formatting](./code-formatting/) - Standards for indentation, line length, and consistent styling.
+- [Naming Conventions](./naming-conventions/) - Guidelines for naming variables, functions, files, and more.
+- [Syntax & Language Features](./syntax-and-language-features/) - Recommendations for modern JavaScript syntax and features.
+- [Code Structure & Organization](./code-structure-and-organization/) - Approaches for structuring modules, files, and components.
+- [Patterns & Best Practices](./patterns-and-best-practices/) - Preferred patterns for error handling, async flow, and data management.
+- [Anti-Patterns](./anti-patterns/) - Common pitfalls to avoid for clean, maintainable code.
+- [Framework-Specific Guidelines](./framework-specific-guidelines/) - Tips for working within specific frameworks like Vue.
+- [Tooling & Automation](./tooling-and-automation/) - Tools and configurations that enforce these guidelines.
+- [Resources](./resources/) - Additional references and helpful external links.
+
+Need help? Start with the [Introduction](./introduction/) or browse the sidebar to dive into a particular topic.


### PR DESCRIPTION
## Summary
- expand homepage with guidance on navigating the docs
- add table of contents linking to major sections with short descriptions

## Testing
- `CI=1 npm run docs:build`

------
https://chatgpt.com/codex/tasks/task_e_689c8638cf848326921655f3e518b6cb