### PR TITLE
docs: illustrate avoiding magic numbers

### DIFF
--- a/docs/anti-patterns/magic-numbers.md
+++ b/docs/anti-patterns/magic-numbers.md
@@ -1,7 +1,24 @@
 # 8.3 Magic Numbers & Strings
-Replace unexplained literals with named constants.
+Replace unexplained literals with named constants. When values are shared across modules, centralize them in enums or configuration files.
 
+### Example
+
+#### Bad
 ```js
-const MAX_ITEMS = 10
+const finalPrice = price * 1.2 - 5
 ```
+
+#### Good
+```js
+// constants.js
+export const TAX_RATE = 0.2
+export const DISCOUNT_AMOUNT = 5
+
+// checkout.js
+import { TAX_RATE, DISCOUNT_AMOUNT } from './constants'
+
+const finalPrice = price * (1 + TAX_RATE) - DISCOUNT_AMOUNT
+```
+
+For values used throughout the codebase, define them once in a shared enum or config file to avoid duplication and ease maintenance. In TypeScript, enums can help centralize related constants.
 


### PR DESCRIPTION
## Summary
- document magic number anti-pattern with before/after calculation example
- note that shared values should live in enums or configuration files
- showcase importing shared constants from a separate module

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c8425d3d883268010478efa72f9d6