### PR TITLE
docs: clarify default parameters behavior

### DIFF
--- a/docs/syntax-and-language-features/default-parameters.md
+++ b/docs/syntax-and-language-features/default-parameters.md
@@ -7,3 +7,35 @@ function greet(name = 'Guest') {
 }
 ```
 
+Defaults are only used when the argument is `undefined`. This differs from a
+`||` fallback, which replaces any falsy value:
+
+```js
+function greetFallback(name) {
+  name = name || 'Guest'
+  return `Hi ${name}`
+}
+
+greet('')        // "Hi "
+greetFallback('') // "Hi Guest"
+```
+
+Default expressions are evaluated left-to-right at call time, so later
+parameters can depend on earlier ones:
+
+```js
+function buildMessage(name = 'Guest', greeting = `Hi ${name}`) {
+  return greeting
+}
+
+buildMessage() // "Hi Guest"
+```
+
+Referencing a later parameter in an earlier default results in a
+`ReferenceError`:
+
+```js
+function bad(a = b, b = 1) {}
+// ReferenceError: Cannot access 'b' before initialization
+```
+


### PR DESCRIPTION
## Summary
- compare parameter defaults with `||` fallbacks
- document evaluation order for default expressions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*
- `npm run docs:build`


------
https://chatgpt.com/codex/tasks/task_e_689c921db5648326b9cb92134512d65d