### PR TITLE
docs: add indentation examples and tooling tips

### DIFF
--- a/docs/code-formatting/indentation-and-spacing.md
+++ b/docs/code-formatting/indentation-and-spacing.md
@@ -1,6 +1,6 @@
 # 3.1 Indentation & Spacing
 
-Use **two spaces** for indentation. Avoid tabs to ensure consistent rendering across different editors and platforms.  
+Use **two spaces** for indentation. Avoid tabs to ensure consistent rendering across different editors and platforms.
 Consistent indentation makes code easier to read and reduces merge conflicts.
 
 **Key points:**
@@ -9,6 +9,8 @@ Consistent indentation makes code easier to read and reduces merge conflicts.
 - Keep code visually aligned for clarity.
 
 ---
+
+### Examples
 
 ::: danger ❌ Bad — inconsistent indentation and mixed tabs/spaces
 ```javascript
@@ -29,4 +31,37 @@ function sayHello(name) {
 }
 ```
 :::
+
+::: tip ✅ 4-space indentation
+```javascript
+function sayHello(name) {
+    console.log("Hello, " + name);
+    console.log("How are you?");
+    console.log("Welcome!");
+}
+```
+:::
+
+### Tooling tips
+
+- **Prettier**: set indentation in your `.prettierrc`:
+
+```json
+{
+  "tabWidth": 2,
+  "useTabs": false
+}
+```
+
+- **ESLint**: enforce indentation with the `indent` rule:
+
+```json
+{
+  "rules": {
+    "indent": ["error", 2]
+  }
+}
+```
+
+Adjust the numeric value to `4` if your project uses four spaces.
 


### PR DESCRIPTION
## Summary
- restore original example highlighting mixed tabs and spaces and add 2- and 4-space fixes
- document Prettier and ESLint settings to enforce indentation rules

## Testing
- `npm test` (fails: Missing script "test")
- `npm run docs:build`


------
https://chatgpt.com/codex/tasks/task_e_689c845ef5948326b6c7f4084346cae2