### PR TITLE
docs: add Prettier examples

### DIFF
--- a/docs/tooling-and-automation/prettier-config.md
+++ b/docs/tooling-and-automation/prettier-config.md
@@ -1,11 +1,30 @@
 # 10.2 Prettier Config
 Format code automatically with a team-approved Prettier setup.
 
+## Sample configuration
+
 ```json
 // .prettierrc
 {
   "singleQuote": true,
-  "semi": false
+  "semi": false,
+  "trailingComma": "es5",
+  "printWidth": 80
 }
 ```
+
+## CLI usage
+
+```bash
+# Check formatting
+npx prettier . --check
+
+# Write formatting changes
+npx prettier . --write
+```
+
+Prettier integrates with other tools for a smoother workflow:
+
+- **VSCode** – install the Prettier extension and enable *Format on Save*.
+- **Husky** – add a pre-commit hook to ensure code is formatted before commits.
 


### PR DESCRIPTION
## Summary
- expand Prettier config docs with sample `.prettierrc`
- document CLI commands for checking and writing formatting
- note integration with VSCode and Husky

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run docs:build`

------
https://chatgpt.com/codex/tasks/task_e_689c924521788326a49856ae47a1c26b