### PR TITLE
docs: add Husky pre-commit lint example

### DIFF
--- a/docs/tooling-and-automation/git-hooks.md
+++ b/docs/tooling-and-automation/git-hooks.md
@@ -1,11 +1,37 @@
 # 10.3 Git Hooks (Husky)
+
 Use Husky to run linting and tests before commits and pushes.
 
-```sh
-// package.json
-"husky": {
-  "hooks": {
-    "pre-commit": "npm run lint"
-  }
-}
-```
+## Example: Run ESLint on `pre-commit`
+
+1. **Install Husky** as a development dependency.
+
+   ```sh
+   npm install --save-dev husky
+   ```
+
+2. **Enable Husky** and ensure it is installed after every `npm install`.
+
+   ```sh
+   npm set-script prepare "husky install"
+   npm run prepare
+   ```
+
+3. **Create a pre-commit hook** that runs your lint script.
+
+   ```sh
+   npx husky add .husky/pre-commit "npm run lint"
+   ```
+
+4. **Define the lint script** in `package.json`.
+
+   ```json
+   {
+     "scripts": {
+       "lint": "eslint ."
+     }
+   }
+   ```
+
+With this setup, ESLint runs automatically before each commit, preventing code that fails linting rules from being committed.
+


### PR DESCRIPTION
## Summary
- expand git hooks docs with Husky example for running lint on pre-commit, including installation and configuration commands

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c923cfb548326b68ea2cb6da95625