### PR TITLE
docs: add ESLint configuration example

### DIFF
--- a/docs/tooling-and-automation/eslint-rules.md
+++ b/docs/tooling-and-automation/eslint-rules.md
@@ -1,11 +1,42 @@
 # 10.1 ESLint Rules
-Use a shared ESLint configuration to enforce these guidelines and catch common errors.
+Use a shared ESLint configuration to enforce these guidelines, catch common errors, and keep code style consistent. Extend from popular base configs like `eslint:recommended` and framework or language presets as needed.
 
 ```json
 // .eslintrc.json
 {
-  "extends": ["eslint:recommended"],
-  "env": { "browser": true }
+  "root": true,
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "rules": {
+    "eqeqeq": "error",
+    "no-unused-vars": "warn"
+  }
 }
 ```
 
+Add a lint script to run ESLint across the project:
+
+```json
+// package.json
+{
+  "scripts": {
+    "lint": "eslint \"**/*.{js,ts,tsx}\""
+  }
+}
+```
+
+Run the linter with:
+
+```bash
+npm run lint
+```


### PR DESCRIPTION
## Summary
- expand ESLint rules guide with sample configuration extending `eslint:recommended` and TypeScript preset
- document package.json lint script and how to run it

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run docs:build`

------
https://chatgpt.com/codex/tasks/task_e_689c9239b0d88326bcfcb877b9880afd