### PR TITLE
docs: illustrate multiline and tagged template literals

### DIFF
--- a/docs/syntax-and-language-features/template-literals.md
+++ b/docs/syntax-and-language-features/template-literals.md
@@ -5,3 +5,25 @@ Use backticks to build strings with variables.
 const message = `Hello, ${name}`
 ```
 
+
+Template literals can span multiple lines, which is useful for composing HTML strings:
+
+```js
+const markup = `
+  <div class="greeting">
+    <h1>Hello, ${name}</h1>
+  </div>
+`
+```
+
+Tagged template literals enable libraries to add custom behavior. Styling libraries like styled-components use them to define CSS:
+
+```js
+import styled from 'styled-components'
+
+const Button = styled.button`
+  background: palevioletred;
+  color: white;
+`
+```
+


### PR DESCRIPTION
## Summary
- document multi-line HTML template strings
- show tagged template usage for styling libraries

## Testing
- `npm test` (fails: Missing script: "test")
- `CI=1 npm run docs:build`


------
https://chatgpt.com/codex/tasks/task_e_689c92361ee48326aee23754d805b52f