### PR TITLE
docs: illustrate let, const, and var scoping

### DIFF
--- a/docs/syntax-and-language-features/let-const-var.md
+++ b/docs/syntax-and-language-features/let-const-var.md
@@ -2,7 +2,22 @@
 Use `const` by default and `let` when reassigning. Avoid `var`.
 
 ```js
-const total = 10
-let count = 0
+function scopeDemo() {
+  if (true) {
+    var functionScoped = 1
+    let blockScoped = 2
+    const constantValue = 3
+    // constantValue = 4 // TypeError: Assignment to constant variable
+  }
+
+  console.log(functionScoped) // 1
+  console.log(blockScoped) // ReferenceError: blockScoped is not defined
+  console.log(constantValue) // ReferenceError: constantValue is not defined
+}
+
+scopeDemo()
 ```
 
+`const` is for values that never change, such as configuration or dependency references.
+`let` is for values that will be reassigned, like counters in loops.
+`var` is function-scoped and should only be used in legacy code.


### PR DESCRIPTION
## Summary
- show block scoping and const immutability in let/const/var guide
- outline common use cases for `const`, `let`, and `var`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run docs:build`

------
https://chatgpt.com/codex/tasks/task_e_689c922ab68483269a9aa05e14a131f0