### PR TITLE
docs: add nested optional chaining examples

### DIFF
--- a/docs/syntax-and-language-features/optional-chaining.md
+++ b/docs/syntax-and-language-features/optional-chaining.md
@@ -4,3 +4,31 @@ Use `?.` and `??` to safely access properties and provide fallbacks.
 ```js
 const title = post?.title ?? 'Untitled'
 ```
+
+Accessing nested properties without optional chaining can cause runtime errors:
+
+```js
+const street = user.address.street
+// TypeError if user or address is undefined
+```
+
+Use optional chaining to prevent errors when traversing nested objects:
+
+```js
+const street = user?.address?.street ?? 'Unknown street'
+```
+
+Accessing array elements without optional chaining can similarly throw errors:
+
+```js
+const firstFriendName = user.friends[0].name
+// TypeError if user, friends, or the first friend is undefined
+```
+
+Use optional chaining with bracket notation to safely access array elements:
+
+```js
+const firstFriendName = user?.friends?.[0]?.name ?? 'Unknown friend'
+// Note the `?.[0]` syntax for optional array access
+```
+


### PR DESCRIPTION
## Summary
- document runtime errors when accessing nested object or array properties without optional chaining
- show how optional chaining with bracket notation and nullish coalescing avoids these errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `CI=1 npm run docs:build`


------
https://chatgpt.com/codex/tasks/task_e_689c922e32448326b8137af658a6448c