### PR TITLE
docs: refine error handling guidance

### DIFF
--- a/docs/patterns-and-best-practices/error-handling.md
+++ b/docs/patterns-and-best-practices/error-handling.md
@@ -9,3 +9,52 @@ try {
 }
 ```
 
+### Philosophy and strategies
+
+- Fail fast in development, but recover gracefully in production.
+- Centralize error handling and logging for consistent behavior.
+- Distinguish between recoverable and unrecoverable errors, offering retries or fallbacks where appropriate.
+- Use monitoring to detect and triage issues early.
+- Avoid swallowing errors; bubble them up or rethrow with contextual information.
+
+Use app-level error boundaries or global handlers to catch runtime exceptions that escape local handlers.
+
+### Vue
+
+```vue
+<script setup>
+import { ref, onErrorCaptured } from 'vue'
+
+const hasError = ref(false)
+onErrorCaptured((error, instance, info) => {
+  hasError.value = true
+  logError(error, info) // send to monitoring service
+  return false // allow parent handlers to run
+})
+</script>
+
+<template>
+  <slot v-if="!hasError" />
+  <p v-else>Something went wrong.</p> <!-- user-facing message -->
+</template>
+```
+
+Frameworks can also register a global handler:
+
+```js
+// Browser
+window.addEventListener('error', (event) => {
+  logError(event.error)
+})
+
+// Vue
+app.config.errorHandler = (err, instance, info) => {
+  logError(err, info)
+}
+```
+
+**User-facing messages vs. logging**
+
+- Show friendly, actionable messages to users without exposing stack traces or sensitive data.
+- Log full error details to the console or a monitoring service for developers to investigate.
+


### PR DESCRIPTION
## Summary
- remove React error boundary example
- add error-handling philosophy and strategies section

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run docs:build`


------
https://chatgpt.com/codex/tasks/task_e_689c86a6547c8326874fffb8b7947712