### PR TITLE
docs: clarify boolean naming

### DIFF
--- a/docs/naming-conventions/boolean-naming.md
+++ b/docs/naming-conventions/boolean-naming.md
@@ -1,5 +1,5 @@
 # 4.5 Boolean Naming
-Prefix booleans with `is`, `has`, or `should` to indicate their nature.
+Prefix booleans with `is`, `has`, `can`, or `should` to indicate their nature. Avoid negative forms that require mental inversion.
 
 ::: danger ❌ Bad Example
 ```javascript
@@ -17,4 +17,39 @@ const shouldDisplay = true;
 ```
 :::
 
+Avoid negative forms that flip meaning and make code harder to read.
+
+::: danger ❌ Bad Example
+```javascript
+const isDisabled = false;
+const hasNoPermission = true;
+const cannotDisplay = false;
+```
+:::
+
+::: tip ✅ Good Example
+```javascript
+const isEnabled = true;
+const hasPermission = false;
+const canDisplay = true;
+```
+:::
+
+Use ESLint's [`@typescript-eslint/naming-convention`](https://typescript-eslint.io/rules/naming-convention/) rule to enforce these prefixes:
+
+```json
+{
+  "rules": {
+    "@typescript-eslint/naming-convention": [
+      "error",
+      {
+        "selector": "variable",
+        "types": ["boolean"],
+        "prefix": ["is", "has", "can", "should"],
+        "format": ["camelCase"]
+      }
+    ]
+  }
+}
+```
 


### PR DESCRIPTION
## Summary
- restore original boolean naming examples
- expand guidance on avoiding negative forms
- document ESLint `@typescript-eslint/naming-convention` rule

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run docs:build`


------
https://chatgpt.com/codex/tasks/task_e_689c866af2d8832689ca7f9434d05298